### PR TITLE
Suggesting callout to usb-c standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USB Cable Tester
 
-Simple board to test various USB cables! (Note the USB standard helps to identify these [USB-C](https://www.usb.org/usb-type-cr-cable-and-connector-specification), cables that are compliant with the standard will have selected pins according to [cable and connector specification release](https://www.usb.org/sites/default/files/USB%20Type-C%202.2%20Release%20202210%20%281%29.zip). 
+Simple board to test various USB cables! (Note the USB standard helps to identify these [USB-C](https://www.usb.org/usb-type-cr-cable-and-connector-specification), cables that are compliant with the standard will have selected pins according to [cable and connector specification release](https://www.usb.org/sites/default/files/USB%20Type-C%202.2%20Release%20202210%20%281%29.zip)). 
 
 Plug in your cable to both sides and see which signals light up!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USB Cable Tester
 
-Simple board to test various USB cables!
+Simple board to test various USB cables! (Note the USB standard helps to identify these [USB-C](https://www.usb.org/usb-type-cr-cable-and-connector-specification), cables that are compliant with the standard will have selected pins according to [cable and connector specification release](https://www.usb.org/sites/default/files/USB%20Type-C%202.2%20Release%20202210%20%281%29.zip). 
 
 Plug in your cable to both sides and see which signals light up!
 


### PR DESCRIPTION
This is a great project! 

This PR requests the addition of links to USB.org for the standards associated with these types of cables.

Specifically the connector and cable specification is really helpful in understanding which cables are possible in the USB standard.

For example consider section 3.5 "Legacy Cable assemblies" -> "USB-C to USB 3.1 standard assembly wiring":
![image](https://user-images.githubusercontent.com/1267018/202922614-d346a6b3-fb9e-4739-a3cf-d93a8f804378.png)


